### PR TITLE
DS18B20 no ACK's examples with sleepy to delay fix

### DIFF
--- a/TinyTX_DS18B20_noACK/TinyTX_DS18B20_noACK.ino
+++ b/TinyTX_DS18B20_noACK/TinyTX_DS18B20_noACK.ino
@@ -1,0 +1,111 @@
+//----------------------------------------------------------------------------------------------------------------------
+// TinyTX - An ATtiny84 and RFM12B Wireless Temperature Sensor Node
+// By Nathan Chantrell. For hardware design see http://nathan.chantrell.net/tinytx
+//
+// Using the Dallas DS18B20 temperature sensor
+//
+// Licenced under the Creative Commons Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0) licence:
+// http://creativecommons.org/licenses/by-sa/3.0/
+//
+// Requires Arduino IDE with arduino-tiny core: http://code.google.com/p/arduino-tiny/
+// and small change to OneWire library, see: http://arduino.cc/forum/index.php/topic,91491.msg687523.html#msg687523
+//----------------------------------------------------------------------------------------------------------------------
+
+#include <OneWire.h> // http://www.pjrc.com/teensy/arduino_libraries/OneWire.zip
+#include <DallasTemperature.h> // http://download.milesburton.com/Arduino/MaximTemperature/DallasTemperature_371Beta.zip
+#include <JeeLib.h> // https://github.com/jcw/jeelib
+
+ISR(WDT_vect) { Sleepy::watchdogEvent(); } // interrupt handler for JeeLabs Sleepy power saving
+
+#define myNodeID 17        // RF12 node ID in the range 1-30 *(17-30 for OpenEnergyMonitor Enviromental Nodes http://openenergymonitor.org/emon/buildingblocks/rfm12b2)*
+#define network 210       // RF12 Network group
+#define freq RF12_433MHZ  // Frequency of RFM12B module
+//#define RETRY_PERIOD 5    // How soon to retry (in seconds) if ACK didn't come in
+//#define RETRY_LIMIT 5     // Maximum number of times to retry
+//#define ACK_TIME 10       // Number of milliseconds to wait for an ack
+
+#define ONE_WIRE_BUS 10   // DS18B20 Temperature sensor is connected on D10/ATtiny pin 13
+#define ONE_WIRE_POWER 9  // DS18B20 Power pin is connected on D9/ATtiny pin 12
+
+OneWire oneWire(ONE_WIRE_BUS); // Setup a oneWire instance
+
+DallasTemperature sensors(&oneWire); // Pass our oneWire reference to Dallas Temperature
+
+//########################################################################################################################
+//Data Structure to be sent
+//########################################################################################################################
+
+ typedef struct {
+  	  int temp;	// Temperature reading
+  	  int supplyV;	// Supply voltage
+ } Payload;
+
+ Payload tinytx;
+
+//########################################################################################################################
+
+void setup() {
+
+  rf12_initialize(myNodeID,freq,network); // Initialize RFM12 with settings defined above 
+  rf12_sleep(0);                          // Put the RFM12 to sleep
+
+  pinMode(ONE_WIRE_POWER, OUTPUT); // set power pin for DS18B20 to output
+  
+  PRR = bit(PRTIM1); // only keep timer 0 going
+  
+  ADCSRA &= ~ bit(ADEN); bitSet(PRR, PRADC); // Disable the ADC to save power
+
+}
+
+void loop() {
+  
+  digitalWrite(ONE_WIRE_POWER, HIGH); // turn DS18B20 sensor on
+
+  //Sleepy::loseSomeTime(10); // Allow 10ms for the sensor to be ready - does not work for me :-(
+  delay(5);                   //works :-) thanks @ianchilton 
+ 
+  sensors.begin(); //start up temp sensor
+  sensors.requestTemperatures(); // Get the temperature
+  tinytx.temp=(sensors.getTempCByIndex(0)*100); // Read first sensor and convert to integer, reversed at receiving end
+  
+  digitalWrite(ONE_WIRE_POWER, LOW); // turn DS18B20 off
+  
+  tinytx.supplyV = readVcc(); // Get supply voltage
+
+  rfwrite(); // Send data via RF 
+
+  Sleepy::loseSomeTime(60000); //JeeLabs power save function: enter low power mode for 60 seconds (valid range 16-65000 ms)
+
+}
+
+//--------------------------------------------------------------------------------------------------
+// Send payload data via RF - with no ACK's
+//-------------------------------------------------------------------------------------------------
+ static void rfwrite(){  
+     rf12_sleep(-1);              // Wake up RF module
+     while (!rf12_canSend())
+     rf12_recvDone();
+     rf12_sendStart(0, &tinytx, sizeof tinytx); 
+     rf12_sendWait(2);           // Wait for RF to finish sending while in standby mode
+     rf12_sleep(0);              // Put RF module to sleep
+     return;    
+ }
+
+
+//--------------------------------------------------------------------------------------------------
+// Read current supply voltage
+//--------------------------------------------------------------------------------------------------
+ long readVcc() {
+   bitClear(PRR, PRADC); ADCSRA |= bit(ADEN); // Enable the ADC
+   long result;
+   // Read 1.1V reference against Vcc
+   ADMUX = _BV(MUX5) | _BV(MUX0);
+   delay(2); // Wait for Vref to settle
+   ADCSRA |= _BV(ADSC); // Convert
+   while (bit_is_set(ADCSRA,ADSC));
+   result = ADCL;
+   result |= ADCH<<8;
+   result = 1126400L / result; // Back-calculate Vcc in mV
+   return result;
+   ADCSRA &= ~ bit(ADEN); bitSet(PRR, PRADC); // Disable the ADC to save power
+} 


### PR DESCRIPTION
Changed Sleepy::loseSomeTime(10); to delay(5)'; after sensor power up. Without fix I either got error value 85 or RF transmission. 
